### PR TITLE
Improved handling for failed workflow runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ release.properties
 *.iml
 *.ipr
 *.iws
+### Additional exclusions
+.classpath
+.project
+.settings/

--- a/src/main/java/com/vmware/vro/jenkins/plugin/OrchestratorCallable.java
+++ b/src/main/java/com/vmware/vro/jenkins/plugin/OrchestratorCallable.java
@@ -18,6 +18,7 @@ public class OrchestratorCallable implements Callable<Map<String, String>, IOExc
     private final BuildParam buildParam;
     private static final String ORCHESTRATOR_WORKFLOW_EXECUTION_STATE = "ORCHESTRATOR_WORKFLOW_EXECUTION_STATE";
     private static final String ORCHESTRATOR_WORKFLOW_EXECUTION_OUTPUT = "ORCHESTRATOR_WORKFLOW_EXECUTION_OUTPUT";
+    private static final String ORCHESTRATOR_WORKFLOW_EXECUTION_EXCEPTION = "ORCHESTRATOR_WORKFLOW_EXECUTION_EXCEPTION";
 
     public OrchestratorCallable(BuildParam buildParam) {
         this.buildParam = buildParam;
@@ -32,40 +33,46 @@ public class OrchestratorCallable implements Callable<Map<String, String>, IOExc
             System.out.println(String.format(
                     "Invoked execute of workflow in the orchestrator server %s resulted in the execution %s",
                     buildParam.getServerUrl(), executeResponseUrl));
-            if (executeResponseUrl != null) {
-                if (buildParam.isWaitExec()) {
-                    //Now wait till the workflow is completed
-                    System.out.println(
-                            "Build is marked and wait till execution is complete. Hence checking the status of " +
-                                    "workflow."
-                    );
-                    ExecutionState executionState = client.fetchWorkflowState(executeResponseUrl);
-                    System.out.println(String.format("Currently workflow is in %s state", executionState.getState()));
-                    while (!executionState.isCompleted()) {
-                        Thread.sleep(10 * 1000);
-                        executionState = client.fetchWorkflowState(executeResponseUrl);
-                        System.out
-                                .println(String.format("Currently workflow is in %s state", executionState.getState()));
-                    }
-                    if (executionState.getState().equalsIgnoreCase("canceled") || executionState.getState()
-                            .equalsIgnoreCase("failed")) {
-                        throw new IOException("Workflow execution failed.");
-                    }
-                    ExecutionOutput executionOutput = client.fetchWorkflowOutputParameters(executeResponseUrl);
-                    System.out.print(String
-                            .format("Workflow completed execution with %s state", executionOutput.getState()));
-                    data.put(ORCHESTRATOR_WORKFLOW_EXECUTION_STATE, executionOutput.getState());
-                    data.put(ORCHESTRATOR_WORKFLOW_EXECUTION_OUTPUT, executionOutput.getParameters());
+
+            if (buildParam.isWaitExec()) {
+                //Now wait till the workflow is completed
+                System.out.println(
+                        "Build is marked and wait till execution is complete. Hence checking the status of " +
+                                "workflow."
+                );
+                ExecutionState executionState = client.fetchWorkflowState(executeResponseUrl);
+                System.out.println(String.format("Currently workflow is in %s state", executionState.getState()));
+
+                while (!executionState.isCompleted()) {
+                    Thread.sleep(10 * 1000);
+                    executionState = client.fetchWorkflowState(executeResponseUrl);
+                    System.out
+                            .println(String.format("Currently workflow is in %s state", executionState.getState()));
                 }
-            } else {
-                System.out.println("System error in execution of workflow.");
-                throw new IOException("Workflow execution failed.");
+
+                //Fetch execution response
+                ExecutionOutput executionOutput = client.fetchWorkflowOutputParameters(executeResponseUrl);
+
+                System.out.print(String
+                        .format("Workflow completed execution with %s state", executionOutput.getState()));
+                data.put(ORCHESTRATOR_WORKFLOW_EXECUTION_STATE, executionOutput.getState());
+                data.put(ORCHESTRATOR_WORKFLOW_EXECUTION_OUTPUT, executionOutput.getParameters());
+
+                if (executionState.getState().equalsIgnoreCase("canceled") || executionState.getState()
+                        .equalsIgnoreCase("failed")) {
+                    data.put(ORCHESTRATOR_WORKFLOW_EXECUTION_EXCEPTION, executionOutput.getException());
+                }
+
             }
+
         } catch (Exception e) {
             e.printStackTrace();
             throw new IOException(e.getMessage(), e);
         }
+
+        // Return data
         return data;
+
     }
 
     @Override

--- a/src/main/java/com/vmware/vro/jenkins/plugin/OrchestratorClient.java
+++ b/src/main/java/com/vmware/vro/jenkins/plugin/OrchestratorClient.java
@@ -36,6 +36,7 @@ public class OrchestratorClient {
     //JSON keys
     private static final String INPUT_PARAMETERS = "input-parameters";
     private static final String OUTPUT_PARAMETERS = "output-parameters";
+    private static final String CONTENT_EXCEPTION = "content-exception";
     private static final String NAME = "name";
     private static final String TYPE = "type";
     private static final String VALUE = "value";
@@ -174,6 +175,10 @@ public class OrchestratorClient {
         if (responseJson.has(OUTPUT_PARAMETERS)) {
             JsonArray jsonArray = responseJson.getAsJsonArray(OUTPUT_PARAMETERS);
             executionOutput.setParameters(jsonArray.toString());
+        }
+        if (responseJson.has(CONTENT_EXCEPTION)) {
+            String exception = responseJson.get(CONTENT_EXCEPTION).getAsString();
+            executionOutput.setException(exception);
         }
         return executionOutput;
     }

--- a/src/main/java/com/vmware/vro/jenkins/plugin/model/ExecutionOutput.java
+++ b/src/main/java/com/vmware/vro/jenkins/plugin/model/ExecutionOutput.java
@@ -9,6 +9,7 @@ public class ExecutionOutput implements Serializable {
 
     private String state;
     private String parameters;
+    private String exception;
 
     public String getState() {
         return state;
@@ -24,5 +25,13 @@ public class ExecutionOutput implements Serializable {
 
     public void setParameters(String parameters) {
         this.parameters = parameters;
+    }
+
+    public String getException() {
+        return exception;
+    }
+
+    public void setException(String exception) {
+        this.exception = exception;
     }
 }


### PR DESCRIPTION
Adds improved support for failed workflow executions.

When a run failed, the job would return with an IOException and no information about why the run failed. Code base has been modified to look at the content-exception property of an execution response (if it's present) and returns a FAILED notification to Jenkins rather than throwing an error.

## OrchestratorBuilder.java
- Added import hudson.model.* and removed individual imports
- Implemented proper build failures for failed workflow runs rather than throwing an error
- Added additional outputParameter ORCHESTRATOR_WORKFLOW_EXECUTION_EXCEPTION to display the contents of content-exception

## OrchestratorCallable.java
- Removed unneeded if statement as execution url will always be present
- If the workflow has failed add ORCHESTRATOR_WORKFLOW_EXECUTION_EXCEPTION to data hashmap and return data rather than throwing an error

## OrchestratorClient.java
- Implemented routine in fetchWorkflowOutputParameter to retrieve content-exception from the execution 

## ExecutionOutput.java
- Implemented getter and setter for excetpion